### PR TITLE
Add export multiple pages

### DIFF
--- a/umlet-elements/src/main/java/com/baselet/element/facet/PropertiesParserState.java
+++ b/umlet-elements/src/main/java/com/baselet/element/facet/PropertiesParserState.java
@@ -29,6 +29,7 @@ public class PropertiesParserState {
 	private StickingPolygonGenerator stickingPolygonGenerator = SimpleStickingPolygonGenerator.INSTANCE;
 	private double totalTextBlockHeight;
 	private final Map<Class<? extends Facet>, Object> facetResponse = new HashMap<Class<? extends Facet>, Object>();
+	private String page;
 
 	public PropertiesParserState(Settings settings, DrawHandler drawer) {
 		this.settings = settings;
@@ -46,6 +47,7 @@ public class PropertiesParserState {
 		this.totalTextBlockHeight = totalTextBlockHeight;
 		facetResponse.clear();
 		drawer.setEnableDrawing(enableDrawing);
+		page = "";
 	}
 
 	public Alignment getAlignment() {
@@ -150,6 +152,14 @@ public class PropertiesParserState {
 
 	public void setDrawer(DrawHandler drawer) {
 		this.drawer = drawer;
+	}
+
+	public void setPage(String page) {
+		this.page = page;
+	}
+
+	public String getPage() {
+		return page;
 	}
 
 }

--- a/umlet-elements/src/main/java/com/baselet/element/facet/Settings.java
+++ b/umlet-elements/src/main/java/com/baselet/element/facet/Settings.java
@@ -21,6 +21,7 @@ import com.baselet.element.facet.common.HorizontalAlignFacet;
 import com.baselet.element.facet.common.LayerFacet;
 import com.baselet.element.facet.common.LineTypeFacet;
 import com.baselet.element.facet.common.LineWidthFacet;
+import com.baselet.element.facet.common.PageFacet;
 import com.baselet.element.facet.common.SeparatorLineFacet;
 import com.baselet.element.facet.common.TextPrintFacet;
 import com.baselet.element.facet.common.TransparencyFacet;
@@ -39,7 +40,7 @@ import com.baselet.element.relation.facet.RelationLineTypeFacet;
  */
 public abstract class Settings {
 	// the following lists are default facet configurations. they are declared here as a simple overview and for easy reuse
-	protected static final List<Facet> BASE = listOf(BackgroundColorFacet.INSTANCE, TransparencyFacet.INSTANCE, ForegroundColorFacet.INSTANCE, LayerFacet.INSTANCE, LineWidthFacet.INSTANCE, GroupFacet.INSTANCE, CommentFacet.INSTANCE);
+	protected static final List<Facet> BASE = listOf(BackgroundColorFacet.INSTANCE, TransparencyFacet.INSTANCE, ForegroundColorFacet.INSTANCE, LayerFacet.INSTANCE, LineWidthFacet.INSTANCE, GroupFacet.INSTANCE, CommentFacet.INSTANCE, PageFacet.INSTANCE);
 	protected static final List<Facet> BASE_WITH_LINETYPE = listOf(BASE, LineTypeFacet.INSTANCE, CustomDrawingFacet.INSTANCE, AdvancedDrawingsFacet.INSTANCE);
 	protected static final List<Facet> BASE_EXTENDED = listOf(BASE_WITH_LINETYPE, TextPrintFacet.INSTANCE, FontSizeFacet.INSTANCE);
 

--- a/umlet-elements/src/main/java/com/baselet/element/facet/common/PageFacet.java
+++ b/umlet-elements/src/main/java/com/baselet/element/facet/common/PageFacet.java
@@ -1,0 +1,27 @@
+package com.baselet.element.facet.common;
+
+import com.baselet.element.facet.FirstRunKeyValueFacet;
+import com.baselet.element.facet.PropertiesParserState;
+
+public class PageFacet extends FirstRunKeyValueFacet {
+
+	public static final PageFacet INSTANCE = new PageFacet();
+
+	private PageFacet() {
+	}
+
+	public static final String KEY = "page";
+	public static final String DEFAULT_VALUE = "";
+
+	@Override
+	public KeyValue getKeyValue() {
+		return new KeyValue(KEY, false, DEFAULT_VALUE.toString(), "Page frame to print");
+	}
+
+	@Override
+	public void handleValue(String value, PropertiesParserState state) {
+		// Check restrictions
+		state.setPage(value);
+	}
+
+}

--- a/umlet-elements/src/main/java/com/baselet/element/facet/common/PageFacet.java
+++ b/umlet-elements/src/main/java/com/baselet/element/facet/common/PageFacet.java
@@ -1,5 +1,6 @@
 package com.baselet.element.facet.common;
 
+import com.baselet.diagram.draw.helper.StyleException;
 import com.baselet.element.facet.FirstRunKeyValueFacet;
 import com.baselet.element.facet.PropertiesParserState;
 
@@ -20,8 +21,13 @@ public class PageFacet extends FirstRunKeyValueFacet {
 
 	@Override
 	public void handleValue(String value, PropertiesParserState state) {
-		// Check restrictions
-		state.setPage(value);
+		if (value.matches("\\S+")) {
+			state.setPage(value);
+		}
+		else {
+			throw new StyleException("page identifier must be text w/o whitespaces");
+		}
+
 	}
 
 }

--- a/umlet-swing/src/main/java/com/baselet/diagram/DrawPanel.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/DrawPanel.java
@@ -190,10 +190,7 @@ public class DrawPanel extends JLayeredPane implements Printable {
 		return gridElements;
 	}
 
-	public List<GridElement> getPageElements() {
-
-		List<GridElement> pageElements = new ArrayList<GridElement>();
-
+	public List<GridElement> getPages() {
 		List<GridElement> pages = new ArrayList<GridElement>();
 
 		// Search for pages
@@ -206,17 +203,21 @@ public class DrawPanel extends JLayeredPane implements Printable {
 			}
 		}
 
+		return pages;
+	}
+
+	public List<GridElement> getPageElements(GridElement page) {
+
+		List<GridElement> pageElements = new ArrayList<GridElement>();
+		pageElements.add(page);
+
 		// Identify the elements per page
-		if (!pages.isEmpty()) {
-			GridElement page = pages.get(0);
-			Rectangle pageArea = page.getRectangle();
-			for (GridElement e : getGridElements()) {
-				if (e.isInRange(pageArea)) {
-					pageElements.add(e);
-				}
+		Rectangle pageArea = page.getRectangle();
+		for (GridElement e : getGridElements()) {
+			if (e.isInRange(pageArea)) {
+				pageElements.add(e);
 			}
 		}
-
 		return pageElements;
 	}
 

--- a/umlet-swing/src/main/java/com/baselet/diagram/DrawPanel.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/DrawPanel.java
@@ -190,6 +190,36 @@ public class DrawPanel extends JLayeredPane implements Printable {
 		return gridElements;
 	}
 
+	public List<GridElement> getPageElements() {
+
+		List<GridElement> pageElements = new ArrayList<GridElement>();
+
+		List<GridElement> pages = new ArrayList<GridElement>();
+
+		// Search for pages
+		for (GridElement e : getGridElements()) {
+			for (String attribute : e.getPanelAttributesAsList()) {
+				if (attribute.matches("^page=.+")) {
+					pages.add(e);
+					break;
+				}
+			}
+		}
+
+		// Identify the elements per page
+		if (!pages.isEmpty()) {
+			GridElement page = pages.get(0);
+			Rectangle pageArea = page.getRectangle();
+			for (GridElement e : getGridElements()) {
+				if (e.isInRange(pageArea)) {
+					pageElements.add(e);
+				}
+			}
+		}
+
+		return pageElements;
+	}
+
 	public List<Relation> getOldRelations() {
 		return getHelper(Relation.class);
 	}

--- a/umlet-swing/src/main/java/com/baselet/diagram/DrawPanel.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/DrawPanel.java
@@ -195,11 +195,8 @@ public class DrawPanel extends JLayeredPane implements Printable {
 
 		// Search for pages
 		for (GridElement e : getGridElements()) {
-			for (String attribute : e.getPanelAttributesAsList()) {
-				if (attribute.matches("^page=.+")) {
-					pages.add(e);
-					break;
-				}
+			if (null != e.getSetting("page")) {
+				pages.add(e);
 			}
 		}
 

--- a/umlet-swing/src/main/java/com/baselet/diagram/io/OutputHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/io/OutputHandler.java
@@ -89,9 +89,8 @@ public class OutputHandler {
 		int oldZoom = handler.getGridSize();
 		handler.setGridAndZoom(Constants.DEFAULTGRIDSIZE, false); // Zoom to the defaultGridsize before execution
 
-		int i = 0;
 		for (GridElement page : handler.getDrawPanel().getPages()) {
-			OutputStream ostream = new FileOutputStream(new File(filenameWholeExport + ".page-" + (++i) + "." + extension));
+			OutputStream ostream = new FileOutputStream(new File(filenameWholeExport + ".page-" + page.getSetting("page") + "." + extension));
 			Collection<GridElement> elementsToDraw = handler.getDrawPanel().getPageElements(page);
 			OutputHandler.exportToOutputStream(extension, ostream, elementsToDraw, handler.getFontHandler());
 			ostream.close();

--- a/umlet-swing/src/main/java/com/baselet/diagram/io/OutputHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/io/OutputHandler.java
@@ -90,7 +90,7 @@ public class OutputHandler {
 		handler.setGridAndZoom(Constants.DEFAULTGRIDSIZE, false); // Zoom to the defaultGridsize before execution
 
 		for (GridElement page : handler.getDrawPanel().getPages()) {
-			OutputStream ostream = new FileOutputStream(new File(filenameWholeExport + ".page-" + page.getSetting("page") + "." + extension));
+			OutputStream ostream = new FileOutputStream(new File(filenameWholeExport + "_" + page.getSetting("page") + "." + extension));
 			Collection<GridElement> elementsToDraw = handler.getDrawPanel().getPageElements(page);
 			OutputHandler.exportToOutputStream(extension, ostream, elementsToDraw, handler.getFontHandler());
 			ostream.close();

--- a/umlet-swing/src/main/java/com/baselet/diagram/io/OutputHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/io/OutputHandler.java
@@ -12,6 +12,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
@@ -48,7 +49,8 @@ import com.itextpdf.text.pdf.PdfWriter;
 
 public class OutputHandler {
 
-	private OutputHandler() {} // private constructor to avoid instantiation
+	private OutputHandler() {
+	} // private constructor to avoid instantiation
 
 	public static void createAndOutputToFile(String extension, File file, DiagramHandler handler) throws Exception {
 		OutputStream ostream = new FileOutputStream(file);
@@ -66,7 +68,11 @@ public class OutputHandler {
 
 		// if nothing is selected, try if there's some page frame defined
 		if (elementsToDraw.isEmpty()) {
-			elementsToDraw = handler.getDrawPanel().getPageElements();
+			List<GridElement> pages = handler.getDrawPanel().getPages();
+
+			if (!pages.isEmpty()) {
+				elementsToDraw = handler.getDrawPanel().getPageElements(pages.get(0));
+			}
 
 			if (elementsToDraw.isEmpty()) {
 				// if no page frame is defined, draw everything

--- a/umlet-swing/src/main/java/com/baselet/diagram/io/OutputHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/io/OutputHandler.java
@@ -83,11 +83,11 @@ public class OutputHandler {
 			return;
 		}
 
-		// File without extension
-		String filenameWholeExport = file.getAbsolutePath().replaceFirst("[.][^.]+$", "");
-
 		int oldZoom = handler.getGridSize();
 		handler.setGridAndZoom(Constants.DEFAULTGRIDSIZE, false); // Zoom to the defaultGridsize before execution
+
+		// File without extension
+		String filenameWholeExport = file.getAbsolutePath().replaceFirst("[.][^.]+$", "");
 
 		for (GridElement page : handler.getDrawPanel().getPages()) {
 			OutputStream ostream = new FileOutputStream(new File(filenameWholeExport + "_" + page.getSetting("page") + "." + extension));

--- a/umlet-swing/src/main/java/com/baselet/diagram/io/OutputHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/io/OutputHandler.java
@@ -63,9 +63,16 @@ public class OutputHandler {
 
 		// if some GridElements are selected, only export them
 		Collection<GridElement> elementsToDraw = handler.getDrawPanel().getSelector().getSelectedElements();
-		// if nothing is selected, draw everything
+
+		// if nothing is selected, try if there's some page frame defined
 		if (elementsToDraw.isEmpty()) {
-			elementsToDraw = handler.getDrawPanel().getGridElements();
+			elementsToDraw = handler.getDrawPanel().getPageElements();
+
+			if (elementsToDraw.isEmpty()) {
+				// if no page frame is defined, draw everything
+				elementsToDraw = handler.getDrawPanel().getGridElements();
+			}
+
 		}
 
 		OutputHandler.exportToOutputStream(extension, ostream, elementsToDraw, handler.getFontHandler());


### PR DESCRIPTION
Umlet shall support an export to 

Usecase: 

I love Umlet's open diagram space without any limits. Very often a a single file starts with a first diagram, an then additional diagrams in the same file appear. Very often I use the sequence interaction frame to draw a frame around each of those diagrams.

I also like 




Todos:
- [ ] Add restriction that page names are unique across diagram

Input: uxf files where at least one element has new attribute "page="



Closer look on input:

![image](https://user-images.githubusercontent.com/8762228/188250525-097957bf-7947-4966-8a31-9b68f4f08d61.png)

![image](https://user-images.githubusercontent.com/8762228/188250632-5855060a-1ef8-4bec-be24-bc1dc955811a.png)



Output (export to e.g. png):

File usecase-multi-page-export.png (as normal export does):
![usecase-multi-page-export](https://user-images.githubusercontent.com/8762228/188250515-b88cc5b0-c3b3-4365-9c03-0ac762519134.png)


File usecase-multi-page-export_bd.png
![usecase-multi-page-export_bd](https://user-images.githubusercontent.com/8762228/188250518-f6c0a9f8-0150-4478-a6bf-980b777fc800.png)

File usecase-multi-page-export_sd.png
![usecase-multi-page-export_sd](https://user-images.githubusercontent.com/8762228/188250519-48d43163-f530-4304-be4c-af4db91761c7.png)
